### PR TITLE
Update to latest version of Burgundy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "github-api"
 description = "Github v3 API bindings for Rust"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["joseph.lenton@askattest.com <joseph.lenton@askattest.com>"]
 repository = "https://github.com/JosephLenton/github-api"
 license = "MIT"
 
 [dependencies]
-burgundy = "0.3.2"
+burgundy = "0.3.3"
 serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_json = "1.0.19"


### PR DESCRIPTION
This fixes an upstream bug where the API can randomly lock up..